### PR TITLE
perf(packman): 复用 git_repository 并在 upgrade 后显示 changelog

### DIFF
--- a/src/core/packman.cpp
+++ b/src/core/packman.cpp
@@ -2,6 +2,7 @@
 
 #include <git2.h>
 #include <git2/errors.h>
+#include <algorithm>
 #include <string>
 #include "core/packman.h"
 #include "core/c-wrapper.h"
@@ -210,6 +211,9 @@ int PackMan::upgradePack(const char *pack) {
   if (err != 0)
     return err;
 
+  // 记录当前commit hash
+  auto old_hash = head(repo);
+
   err = pull(repo);
   if (err < 0)
     return err;
@@ -220,6 +224,13 @@ int PackMan::upgradePack(const char *pack) {
   err = checkout_branch(repo, "master");
   if (err < 0)
     return err;
+
+  auto hash = head(repo);
+  auto commit_range = fmt::format("{}..{}", old_hash, hash);
+  auto changelog = generate_changelog(repo, commit_range.c_str());
+  if (!changelog.empty()) {
+    spdlog::info("New changes of package '{}':\n{}", pack, changelog);
+  }
 
   db->exec(fmt::format("UPDATE packages SET hash = '{}' WHERE name = '{}';",
                   head(repo), pack));
@@ -479,6 +490,125 @@ std::string PackMan::head(git_repository *repo) {
 clean:
   git_object_free(obj);
   return "0000000000000000000000000000000000000000";
+}
+
+struct ConvCommit {
+  std::string raw_message_head;
+  enum { Feat, Fix } type;
+  bool breaking = false;
+  std::string subtype;
+  std::string message_title;
+};
+
+// 根据Conventional Commit规范，对于给定commit_range生成摘要
+// 但是实际上是简化版方法，只检测feat: 和 fix:，以及他俩携带括号的版本和携带感叹号的版本
+// 比如feat(foo)!: message title\n\n  LONG MESSAGE BODY
+// 这单独一条显示为 - **破坏性!** (foo) message title
+std::string PackMan::generate_changelog(git_repository *repo, const char *commit_range) {
+  int err;
+  git_revwalk *walk = NULL;
+  git_oid oid;
+  std::vector<ConvCommit> feats;
+  std::vector<ConvCommit> fixes;
+  std::string result;
+
+  err = git_revwalk_new(&walk, repo);
+  GIT_CHK_CLEAN;
+
+  err = git_revwalk_push_range(walk, commit_range);
+  GIT_CHK_CLEAN;
+
+  while (!git_revwalk_next(&oid, walk)) {
+    git_commit *commit = NULL;
+    err = git_commit_lookup(&commit, repo, &oid);
+    if (err < 0) continue;
+
+    const char *msg = git_commit_message(commit);
+    std::string msg_str(msg);
+    auto first_line = msg_str.substr(0, msg_str.find('\n'));
+
+    ConvCommit cc;
+    cc.raw_message_head = first_line;
+
+    size_t pos = 0;
+    if (first_line.starts_with("feat")) {
+      cc.type = ConvCommit::Feat;
+      pos = 4;
+    } else if (first_line.starts_with("fix")) {
+      cc.type = ConvCommit::Fix;
+      pos = 3;
+    } else {
+      git_commit_free(commit);
+      continue;
+    }
+
+    if (pos < first_line.size() && first_line[pos] == '(') {
+      size_t end = first_line.find(')', pos);
+      if (end != std::string::npos) {
+        cc.subtype = first_line.substr(pos + 1, end - pos - 1);
+        pos = end + 1;
+      }
+    }
+
+    if (pos < first_line.size() && first_line[pos] == '!') {
+      cc.breaking = true;
+      pos++;
+    }
+
+    if (pos < first_line.size() && first_line[pos] == ':') {
+      pos++;
+      if (pos < first_line.size() && first_line[pos] == ' ') {
+        pos++;
+      }
+    }
+
+    cc.message_title = first_line.substr(pos);
+
+    if (cc.type == ConvCommit::Feat) {
+      feats.push_back(cc);
+    } else {
+      fixes.push_back(cc);
+    }
+
+    git_commit_free(commit);
+  }
+
+  std::reverse(feats.begin(), feats.end());
+  std::reverse(fixes.begin(), fixes.end());
+
+  if (!feats.empty()) {
+    result += "## Feature(s)\n\n";
+    for (const auto &c : feats) {
+      result += "- ";
+      if (c.breaking) {
+        result += "**BREAKING!** ";
+      }
+      if (!c.subtype.empty()) {
+        result += "(" + c.subtype + ") ";
+      }
+      result += c.message_title + "\n";
+    }
+    result += "\n";
+  }
+
+  if (!fixes.empty()) {
+    result += "## Fix(es)\n\n";
+    for (const auto &c : fixes) {
+      result += "- ";
+      if (c.breaking) {
+        result += "**BREAKING!** ";
+      }
+      if (!c.subtype.empty()) {
+        result += "(" + c.subtype + ") ";
+      }
+      result += c.message_title + "\n";
+    }
+    result += "\n";
+  }
+
+clean:
+  git_revwalk_free(walk);
+  return result;
 }
 
 #undef GIT_FAIL

--- a/src/core/packman.cpp
+++ b/src/core/packman.cpp
@@ -14,12 +14,12 @@ static std::unique_ptr<PackMan> pacman_instance = nullptr;
 PackMan &PackMan::instance() {
   if (!pacman_instance) {
     pacman_instance = std::unique_ptr<PackMan>(new PackMan);
-  }
 
 #ifdef FK_EMBEDDED
-  // 静态编译版中，需要手动打包certs文件，过老的系统里面的证书不太可靠
-  git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, NULL, "./certs");
+    // 静态编译版中，需要手动打包certs文件，过老的系统里面的证书不太可靠
+    git_libgit2_opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, NULL, "./certs");
 #endif
+  }
 
   return *pacman_instance;
 }
@@ -71,6 +71,16 @@ void PackMan::refreshSummary() {
   m_summary = std::string(bin.begin(), bin.end());
 }
 
+// RAII wrapper for libgit2 git_repository
+struct PackMan::GitRepo {
+  git_repository *repo = NULL;
+
+  GitRepo() noexcept = default;
+  GitRepo(GitRepo &) = delete;
+  GitRepo(GitRepo &&) = delete;
+  ~GitRepo() { if (repo) git_repository_free(repo); }
+};
+
 
 /*
 void PackMan::loadSummary(const QString &jsonData, bool useThread) {
@@ -119,9 +129,12 @@ int PackMan::downloadNewPack(const char *u) {
   static constexpr const char *sql_update = "INSERT INTO packages (name,url,hash,enabled) \
     VALUES ('{}','{}','{}',1);";
 
-  int err = clone(u);
+  GitRepo raii_repo;
+  int err = clone(u, raii_repo);
   if (err < 0)
     return err;
+
+  auto repo = raii_repo.repo;
 
   auto url = std::string { u };
   while (!url.empty() && url.back() == '/') {
@@ -135,7 +148,7 @@ int PackMan::downloadNewPack(const char *u) {
 
   auto result = db->select(fmt::format(sql_select, fileName));
   if (result.empty()) {
-    db->exec(fmt::format(sql_update, fileName, url, head(fileName.c_str())));
+    db->exec(fmt::format(sql_update, fileName, url, head(repo)));
   }
 
   return err;
@@ -166,38 +179,50 @@ void PackMan::disablePack(const char *pack) {
 }
 
 int PackMan::updatePack(const char *pack, const char *hash) {
-  int err;
-  // 先status 检查dirty 后面全是带--force的操作
-  err = status(pack);
-  if (err != 0)
-    return err;
-  err = pull(pack);
+  GitRepo raii_repo;
+  int err = open(pack, raii_repo);
   if (err < 0)
     return err;
-  err = checkout(pack, hash);
+  auto repo = raii_repo.repo;
+
+  // 先status 检查dirty 后面全是带--force的操作
+  err = status(repo);
+  if (err != 0)
+    return err;
+  err = pull(repo);
+  if (err < 0)
+    return err;
+  err = checkout(repo, hash);
   if (err < 0)
     return err;
   return 0;
 }
 
 int PackMan::upgradePack(const char *pack) {
-  int err;
-  // 先status 检查dirty 后面全是带--force的操作
-  err = status(pack);
-  if (err != 0)
-    return err;
-  err = pull(pack);
+  GitRepo raii_repo;
+  int err = open(pack, raii_repo);
   if (err < 0)
     return err;
+  auto repo = raii_repo.repo;
+
+  // 先status 检查dirty 后面全是带--force的操作
+  err = status(repo);
+  if (err != 0)
+    return err;
+
+  err = pull(repo);
+  if (err < 0)
+    return err;
+
   // 至此upgrade命令把包升到了FETCH_HEAD的commit
   // 我们稍微操作一下，让HEAD指向最新的master
   // 这样以后就能开新分支干活了
-  err = checkout_branch(pack, "master");
+  err = checkout_branch(repo, "master");
   if (err < 0)
     return err;
 
   db->exec(fmt::format("UPDATE packages SET hash = '{}' WHERE name = '{}';",
-                  head(pack), pack));
+                  head(repo), pack));
   return 0;
 }
 
@@ -221,14 +246,22 @@ Sqlite3::QueryResult PackMan::listPackages() {
 }
 
 void PackMan::forceCheckoutMaster(const char *pack) {
-  checkout_branch(pack, "master");
+  GitRepo repo;
+  int err = open(pack, repo);
+  if (err < 0)
+    return;
+  checkout_branch(repo.repo, "master");
 }
 
 void PackMan::syncCommitHashToDatabase() {
   for (auto e : db->select("SELECT name FROM packages;")) {
     auto pack = e["name"];
+    GitRepo repo;
+    int err = open(pack.c_str(), repo);
+    if (err < 0)
+      continue;
     db->exec(fmt::format("UPDATE packages SET hash = '{}' WHERE name = '{}';",
-             head(pack.c_str()), pack));
+             head(repo.repo), pack));
   }
 }
 
@@ -241,6 +274,18 @@ void PackMan::syncCommitHashToDatabase() {
     GIT_FAIL;          \
     goto clean;        \
   }
+
+int PackMan::open(const char *name, GitRepo &repo) {
+  git_repository *raw = NULL;
+  auto path = fmt::format("packages/{}", name);
+  int err = git_repository_open(&raw, path.c_str());
+  if (err < 0) {
+    GIT_FAIL;
+    return err;
+  }
+  repo.repo = raw;
+  return 0;
+}
 
 static int transfer_progress_cb(const git_indexer_progress *stats,
                                 void *payload) {
@@ -256,8 +301,7 @@ static int transfer_progress_cb(const git_indexer_progress *stats,
   return 0;
 }
 
-int PackMan::clone(const char *u) {
-  git_repository *repo = NULL;
+int PackMan::clone(const char *u, GitRepo &repo) {
   auto url = std::string { u };
   while (!url.empty() && url.back() == '/') {
     url.pop_back();
@@ -269,11 +313,12 @@ int PackMan::clone(const char *u) {
   }
   auto clonePath = std::filesystem::path("packages") / fileName;
 
+  git_repository *raw = NULL;
   git_clone_options opt;
   git_clone_init_options(&opt, GIT_CLONE_OPTIONS_VERSION);
   opt.fetch_opts.proxy_opts.version = 1;
   opt.fetch_opts.callbacks.transfer_progress = transfer_progress_cb;
-  int err = git_clone(&repo, url.c_str(), clonePath.string().c_str(), &opt);
+  int err = git_clone(&raw, url.c_str(), clonePath.string().c_str(), &opt);
   if (err < 0) {
     std::error_code ec;
     std::filesystem::remove_all(clonePath, ec);
@@ -282,20 +327,17 @@ int PackMan::clone(const char *u) {
     }
     GIT_FAIL;
   } else {
+    repo.repo = raw;
     printf("\n");
   }
 
-// clean:
-  git_repository_free(repo);
   return err;
 }
 
 // git fetch && git checkout FETCH_HEAD -f
-int PackMan::pull(const char *name) {
-  git_repository *repo = NULL;
+int PackMan::pull(git_repository *repo) {
   int err;
   git_remote *remote = NULL;
-  auto path = fmt::format("packages/{}", name);
   git_fetch_options opt;
   git_fetch_init_options(&opt, GIT_FETCH_OPTIONS_VERSION);
   opt.proxy_opts.version = 1;
@@ -303,9 +345,6 @@ int PackMan::pull(const char *name) {
 
   git_checkout_options opt2 = GIT_CHECKOUT_OPTIONS_INIT;
   opt2.checkout_strategy = GIT_CHECKOUT_FORCE;
-
-  err = git_repository_open(&repo, path.c_str());
-  GIT_CHK_CLEAN;
 
   // first git fetch origin
   err = git_remote_lookup(&remote, repo, "origin");
@@ -325,19 +364,14 @@ int PackMan::pull(const char *name) {
 
 clean:
   git_remote_free(remote);
-  git_repository_free(repo);
   return err;
 }
 
-int PackMan::checkout(const char *name, const char *hash) {
-  git_repository *repo = NULL;
+int PackMan::checkout(git_repository *repo, const char *hash) {
   int err;
   git_oid oid = {0};
   git_checkout_options opt = GIT_CHECKOUT_OPTIONS_INIT;
   opt.checkout_strategy = GIT_CHECKOUT_FORCE;
-  auto path = fmt::format("packages/{}", name);
-  err = git_repository_open(&repo, path.c_str());
-  GIT_CHK_CLEAN;
   err = git_oid_fromstr(&oid, hash);
   GIT_CHK_CLEAN;
   err = git_repository_set_head_detached(repo, &oid);
@@ -346,13 +380,11 @@ int PackMan::checkout(const char *name, const char *hash) {
   GIT_CHK_CLEAN;
 
 clean:
-  git_repository_free(repo);
   return err;
 }
 
 // git checkout -B branch origin/branch --force
-int PackMan::checkout_branch(const char *name, const char *branch) {
-  git_repository *repo = NULL;
+int PackMan::checkout_branch(git_repository *repo, const char *branch) {
   git_oid oid = {0};
   int err;
   git_object *obj = NULL;
@@ -364,11 +396,6 @@ int PackMan::checkout_branch(const char *name, const char *branch) {
 
   std::string local_branch;
   std::string remote_branch;
-
-  // 打开仓库
-  auto path = fmt::format("packages/{}", name);
-  err = git_repository_open(&repo, path.c_str());
-  GIT_CHK_CLEAN;
 
   // 查找远程分支的引用 (refs/remotes/origin/branch)
   remote_branch = fmt::format("refs/remotes/origin/{}", branch);
@@ -409,20 +436,15 @@ clean:
   git_reference_free(branch_ref);
   git_reference_free(remote_ref);
   git_object_free(obj);
-  git_repository_free(repo);
 
   return err;
 }
 
-int PackMan::status(const char *name) {
-  git_repository *repo = NULL;
+int PackMan::status(git_repository *repo) {
   int err;
   git_status_list *status_list = NULL;
   size_t i, maxi;
   const git_status_entry *s;
-  auto path = fmt::format("packages/{}", name);
-  err = git_repository_open(&repo, path.c_str());
-  GIT_CHK_CLEAN;
   err = git_status_list_new(&status_list, repo, NULL);
   GIT_CHK_CLEAN;
   maxi = git_status_list_entrycount(status_list);
@@ -431,7 +453,6 @@ int PackMan::status(const char *name) {
     s = git_status_byindex(status_list, i);
     if (s->status != GIT_STATUS_CURRENT && s->status != GIT_STATUS_IGNORED) {
       git_status_list_free(status_list);
-      git_repository_free(repo);
       spdlog::error("Workspace is dirty.");
       return 100;
     }
@@ -439,31 +460,24 @@ int PackMan::status(const char *name) {
 
 clean:
   git_status_list_free(status_list);
-  git_repository_free(repo);
   return err;
 }
 
-std::string PackMan::head(const char *name) {
-  git_repository *repo = NULL;
+std::string PackMan::head(git_repository *repo) {
   int err;
   git_object *obj = NULL;
   const git_oid *oid;
   char buf[42] = {0};
-  auto path = fmt::format("packages/{}", name);
-  err = git_repository_open(&repo, path.c_str());
-  GIT_CHK_CLEAN;
   err = git_revparse_single(&obj, repo, "HEAD");
   GIT_CHK_CLEAN;
 
   oid = git_object_id(obj);
   git_oid_tostr(buf, 41, oid);
   git_object_free(obj);
-  git_repository_free(repo);
   return std::string { buf };
 
 clean:
   git_object_free(obj);
-  git_repository_free(repo);
   return "0000000000000000000000000000000000000000";
 }
 

--- a/src/core/packman.h
+++ b/src/core/packman.h
@@ -53,4 +53,5 @@ private:
   int checkout_branch(git_repository *repo, const char *branch);
   int status(git_repository *repo); // return 1 if the workdir is modified
   std::string head(git_repository *repo); // get commit hash of HEAD
+  std::string generate_changelog(git_repository *repo, const char *commit_range);
 };

--- a/src/core/packman.h
+++ b/src/core/packman.h
@@ -4,6 +4,8 @@
 
 #include "c-wrapper.h"
 
+struct git_repository;
+
 class PackMan {
 
 public:
@@ -42,10 +44,13 @@ private:
 
   std::string m_summary;
 
-  int clone(const char *url);
-  int pull(const char *name);
-  int checkout(const char *name, const char *hash);
-  int checkout_branch(const char *name, const char *branch);
-  int status(const char *name); // return 1 if the workdir is modified
-  std::string head(const char *name); // get commit hash of HEAD
+  struct GitRepo;
+
+  int open(const char *name, GitRepo &repo);
+  int clone(const char *url, GitRepo &repo);
+  int pull(git_repository *repo);
+  int checkout(git_repository *repo, const char *hash);
+  int checkout_branch(git_repository *repo, const char *branch);
+  int status(git_repository *repo); // return 1 if the workdir is modified
+  std::string head(git_repository *repo); // get commit hash of HEAD
 };


### PR DESCRIPTION
## Summary
- 通过 RAII `GitRepo` 在 PackMan 操作链中复用已打开的 `git_repository`，避免反复 open/free
- `upgrade` 后根据新旧 commit 区间生成并显示 changelog

## Test plan
- [ ] 安装/更新扩展包，确认 clone、pull、checkout、status 行为正常
- [ ] 对已安装包执行 upgrade，确认能输出对应 commit changelog
- [ ] 工作区 dirty 时 update/upgrade 仍能正确报错